### PR TITLE
chore: configure CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code Owners for gcp-env
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @airman604


### PR DESCRIPTION
This PR configures `dir: .github/CODEOWNERS` to set @airman604 as the code owner for all files across the whole repository.